### PR TITLE
English language JS error fix

### DIFF
--- a/views/manager/_form.php
+++ b/views/manager/_form.php
@@ -24,10 +24,9 @@ $settings = [
         'fullscreen',
     ],
 ];
-if (!in_array(Yii::$app->language, ['en', 'en_US', 'en-US'])) {
+if (stripos(Yii::$app->language, 'en') !== false) {
     $settings['lang'] = Yii::$app->language;
 }
-
 if ($module->addImage || $module->uploadImage) {
     $settings['plugins'][] = 'imagemanager';
 }

--- a/views/manager/_form.php
+++ b/views/manager/_form.php
@@ -24,7 +24,7 @@ $settings = [
         'fullscreen',
     ],
 ];
-if (stripos(Yii::$app->language, 'en') !== false) {
+if (stripos(Yii::$app->language, 'en') === false) {
     $settings['lang'] = Yii::$app->language;
 }
 if ($module->addImage || $module->uploadImage) {

--- a/views/manager/_form.php
+++ b/views/manager/_form.php
@@ -24,7 +24,7 @@ $settings = [
         'fullscreen',
     ],
 ];
-if (stripos(Yii::$app->language, 'en') === false) {
+if (stripos(Yii::$app->language, 'en') !== 0) {
     $settings['lang'] = Yii::$app->language;
 }
 if ($module->addImage || $module->uploadImage) {

--- a/views/manager/_form.php
+++ b/views/manager/_form.php
@@ -19,12 +19,15 @@ echo $form->field($model, 'alias')->textInput(['maxlength' => 255]);
 echo $form->field($model, 'published')->checkbox();
 
 $settings = [
-    'lang' => Yii::$app->language,
     'minHeight' => 200,
     'plugins' => [
         'fullscreen',
     ],
 ];
+if (!in_array(Yii::$app->language, ['en', 'en_US', 'en-US'])) {
+    $settings['lang'] = Yii::$app->language;
+}
+
 if ($module->addImage || $module->uploadImage) {
     $settings['plugins'][] = 'imagemanager';
 }


### PR DESCRIPTION
Hi! Nice extension!
I've just installed it and found a little issue.
In case your website has **EN** language as default (or 'lang' not setted at all) then Yii2Pages throws **JS error** on the manager/create page (**_form.php** view).
Please see screenshot.
![yii2pagesissue](https://cloud.githubusercontent.com/assets/5050758/14315764/75dda11c-fc29-11e5-8d24-0a138b501377.png)
The problem is **yii2-imperavi-widget** doesn't generate en.js file (i think, because it uses as default) into the assets/ directory and widget doesn't work in this case.
I've fixed it by checking current language and specifying 'lang' only if it's not EN
