### PR TITLE
Fix default value of boolean field in migration

### DIFF
--- a/src/migrations/m150429_155009_create_page_table.php
+++ b/src/migrations/m150429_155009_create_page_table.php
@@ -14,13 +14,13 @@ class m150429_155009_create_page_table extends Migration
      * @var string
      */
     private $_tableName;
-    
+
     public function init()
     {
         parent::init();
         $this->_tableName = Yii::$app->getModule('pages')->tableName;
     }
-    
+
     public function up()
     {
         $tableOptions = null;
@@ -35,7 +35,7 @@ class m150429_155009_create_page_table extends Migration
                 'id' => Schema::TYPE_PK,
                 'title' => Schema::TYPE_STRING . ' NOT NULL',
                 'alias' => Schema::TYPE_STRING . ' NOT NULL',
-                'published' => Schema::TYPE_BOOLEAN . ' DEFAULT 1',
+                'published' => Schema::TYPE_BOOLEAN . ' DEFAULT TRUE',
                 'content' => Schema::TYPE_TEXT,
                 'title_browser' => Schema::TYPE_STRING,
                 'meta_keywords' => Schema::TYPE_STRING . '(200)',

--- a/src/migrations/m180927_200917_add_display_title.php
+++ b/src/migrations/m180927_200917_add_display_title.php
@@ -22,7 +22,7 @@ class m180927_200917_add_display_title extends Migration
 
     public function safeUp()
     {
-        $this->addColumn($this->_tableName, 'display_title', Schema::TYPE_BOOLEAN . ' DEFAULT 1');
+        $this->addColumn($this->_tableName, 'display_title', Schema::TYPE_BOOLEAN . ' DEFAULT TRUE');
     }
 
     public function safeDown()


### PR DESCRIPTION
The code below in `m150429_155009_create_page_table.php` causes error when run with PostgreSQL
```'published' => Schema::TYPE_BOOLEAN . ' DEFAULT 1',```
The bug fix as below will work for MySQL, PostgreSQL.
```'published' => Schema::TYPE_BOOLEAN . ' DEFAULT TRUE',```

The same issue in `m180927_200917_add_display_title.php` for `display_title` field.